### PR TITLE
Adding opat directory from opat repo.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,8 @@ ga:
 primary_navigation:
   - name: Home
     url: /
+  - name: OPATs
+    url: /opats/
   - name: Blog
     url: /blog/
   - name: Document

--- a/_pages/opats.md
+++ b/_pages/opats.md
@@ -1,0 +1,10 @@
+---
+title: OPAT Accessibility Conformance Reports
+layout: wide
+sidenav: false
+permalink: /opats/
+---
+
+<div class="grid-container">
+    <iframe src="/opat/index.html" title="OPAT Accessibility Conformance Reports table report" width="100%" height="700px" style="border: 0;"></iframe>
+</div>

--- a/catalog/2.4-edition-wcag-2.0-508-en.yaml
+++ b/catalog/2.4-edition-wcag-2.0-508-en.yaml
@@ -1,0 +1,1038 @@
+title: VPAT® 2.4 Revised Section 508 Edition
+lang: en
+standards:
+  - id: wcag-2.0
+    label: Web Content Accessibility Guidelines 2.0
+    report_heading: WCAG 2.0 Report
+    url: https://www.w3.org/TR/WCAG20/
+    chapters:
+      - success_criteria_level_a
+      - success_criteria_level_aa
+      - success_criteria_level_aaa
+  - id: "508"
+    label: >-
+      Revised Section 508 standards published January 18, 2017 and corrected
+      January 22, 2018
+    report_heading: Revised Section 508 Report
+    url: https://www.access-board.gov/ict/
+    chapters:
+      - functional_performance_criteria
+      - hardware
+      - software
+      - support_documentation_and_services
+chapters:
+  - id: success_criteria_level_a
+    label: "Table 1: Success Criteria, Level A"
+    order: 1
+    criteria:
+      - id: 1.1.1
+        handle: Non-text Content
+        alt_id: text-equiv-all
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.1
+        handle: Audio-only and Video-only (Prerecorded)
+        alt_id: media-equiv-av-only-alt
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.2
+        handle: Captions (Prerecorded)
+        alt_id: media-equiv-captions
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.3
+        handle: Audio Description or Media Alternative (Prerecorded)
+        alt_id: media-equiv-audio-desc
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.3.1
+        handle: Info and Relationships
+        alt_id: content-structure-separation-programmatic
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.3.2
+        handle: Meaningful Sequence
+        alt_id: content-structure-separation-sequence
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.3.3
+        handle: Sensory Characteristics
+        alt_id: content-structure-separation-understanding
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.1
+        handle: Use of Color
+        alt_id: visual-audio-contrast-without-color
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.2
+        handle: Audio Control
+        alt_id: visual-audio-contrast-dis-audio
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.1.1
+        handle: Keyboard
+        alt_id: keyboard-operation-keyboard-operable
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.1.2
+        handle: No Keyboard Trap
+        alt_id: keyboard-operation-trapping
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.2.1
+        handle: Pause, Stop, Hide
+        alt_id: time-limits-required-behaviors
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.2.2
+        handle: Timing Adjustable
+        alt_id: time-limits-pause
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.3.1
+        handle: Three Flashes or Below Threshold
+        alt_id: seizure-does-not-violate
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.1
+        handle: Bypass Blocks
+        alt_id: navigation-mechanisms-skip
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.2
+        handle: Page Titled
+        alt_id: navigation-mechanisms-title
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.3
+        handle: Focus Order
+        alt_id: navigation-mechanisms-focus-order
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.4
+        handle: Link Purpose (In Context)
+        alt_id: navigation-mechanisms-refs
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.1
+        handle: Language of Page
+        alt_id: meaning-doc-lang-id
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.2.1
+        handle: On Focus
+        alt_id: consistent-behavior-receive-focus
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.2.2
+        handle: On Input
+        alt_id: consistent-behavior-unpredictable-change
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.1
+        handle: Error Identification
+        alt_id: minimize-error-identified
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.2
+        handle: Labels or Instructions
+        alt_id: minimize-error-cues
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 4.1.1
+        handle: Parsing
+        alt_id: ensure-compat-parses
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 4.1.2
+        handle: Name, Role, Value
+        alt_id: ensure-compat-rsv
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+  - id: success_criteria_level_aa
+    label: "Table 2: Success Criteria, Level AA"
+    order: 2
+    criteria:
+      - id: 1.2.4
+        handle: Captions (Live)
+        alt_id: media-equiv-real-time-captions
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.5
+        handle: Audio Description (Prerecorded)
+        alt_id: media-equiv-audio-desc-only
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.3
+        handle: Contrast (Minimum)
+        alt_id: visual-audio-contrast-contrast
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.4
+        handle: Resize text
+        alt_id: visual-audio-contrast-scale
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.5
+        handle: Images of Text
+        alt_id: visual-audio-contrast-text-presentation
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.5
+        handle: Multiple Ways
+        alt_id: navigation-mechanisms-mult-loc
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.6
+        handle: Headings and Labels
+        alt_id: navigation-mechanisms-descriptive
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.7
+        handle: Focus Visible
+        alt_id: navigation-mechanisms-focus-visible
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.2
+        handle: Language of Parts
+        alt_id: meaning-other-lang-id
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.2.3
+        handle: Consistent Navigation
+        alt_id: consistent-behavior-consistent-locations
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.2.4
+        handle: Consistent Identification
+        alt_id: consistent-behavior-consistent-functionality
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.3
+        handle: Error Suggestion
+        alt_id: minimize-error-suggestions
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.4
+        handle: Error Prevention (Legal, Financial, Data)
+        alt_id: minimize-error-reversible
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+  - id: success_criteria_level_aaa
+    label: "Table 3: Success Criteria, Level AAA"
+    order: 3
+    criteria:
+      - id: 1.2.6
+        handle: Sign Language (Prerecorded)
+        alt_id: media-equiv-sign
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.7
+        handle: Extended Audio Description (Prerecorded)
+        alt_id: media-equiv-extended-ad
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.8
+        handle: Media Alternative (Prerecorded)
+        alt_id: media-equiv-text-doc
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.2.9
+        handle: Audio-only (Live)
+        alt_id: media-equiv-live-audio-only
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.6
+        handle: Contrast (Enhanced)
+        alt_id: visual-audio-contrast7
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.7
+        handle: Low or No Background Audio
+        alt_id: visual-audio-contrast-noaudio
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.8
+        handle: Visual Presentation
+        alt_id: visual-audio-contrast-visual-presentation
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 1.4.9
+        handle: Images of Text (No Exception)
+        alt_id: visual-audio-contrast-text-images
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.1.3
+        handle: Keyboard (No Exception)
+        alt_id: keyboard-operation-all-funcs
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.2.3
+        handle: No Timing
+        alt_id: time-limits-no-exceptions
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.2.4
+        handle: Interruptions
+        alt_id: time-limits-postponed
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.2.5
+        handle: Re-authenticating
+        alt_id: time-limits-server-timeout
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.3.2
+        handle: Three Flashes
+        alt_id: seizure-three-times
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.8
+        handle: Location
+        alt_id: navigation-mechanisms-location
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.9
+        handle: Link Purpose (Link Only)
+        alt_id: navigation-mechanisms-link
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 2.4.10
+        handle: Section Headings
+        alt_id: navigation-mechanisms-headings
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.3
+        handle: Unusual Words
+        alt_id: meaning-idioms
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.4
+        handle: Abbreviations
+        alt_id: meaning-located
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.5
+        handle: Reading Level
+        alt_id: meaning-supplements
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.1.6
+        handle: Pronunciation
+        alt_id: meaning-pronunciation
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.2.5
+        handle: Change on Request
+        alt_id: consistent-behavior-no-extreme-changes-context
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.5
+        handle: Help
+        alt_id: minimize-error-context-help
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+      - id: 3.3.6
+        handle: Error Prevention (All)
+        alt_id: minimize-error-reversible-all
+        components:
+          - web
+          - electronic-docs
+          - software
+          - authoring-tool
+  - id: functional_performance_criteria
+    label: "Chapter 3: Functional Performance Criteria (FPC)"
+    order: 3
+    criteria:
+      - id: "302.1"
+        handle: Without Vision
+        alt_id: "302.1"
+        components:
+          - none
+      - id: "302.2"
+        handle: With Limited Vision
+        alt_id: "302.2"
+        components:
+          - none
+      - id: "302.3"
+        handle: Without Perception of Color
+        alt_id: "302.3"
+        components:
+          - none
+      - id: "302.4"
+        handle: Without Hearing
+        alt_id: "302.4"
+        components:
+          - none
+      - id: "302.5"
+        handle: With Limited Hearing
+        alt_id: "302.5"
+        components:
+          - none
+      - id: "302.6"
+        handle: Without Speech
+        alt_id: "302.6"
+        components:
+          - none
+      - id: "302.7"
+        handle: With Limited Manipulation
+        alt_id: "302.7"
+        components:
+          - none
+      - id: "302.8"
+        handle: With Limited Reach and Strength
+        alt_id: "302.8"
+        components:
+          - none
+      - id: "302.9"
+        handle: With Limited Language, Cognitive, and Learning Abilities
+        alt_id: "302.9"
+        components:
+          - none
+  - id: hardware
+    label: "Chapter 4: Hardware"
+    chapter_title: Chapter 4
+    order: 4
+    criteria:
+      - id: 402.2.1
+        handle: Information Displayed On-Screen
+        alt_id: 402.2.1
+        components:
+          - none
+      - id: 402.2.2
+        handle: Transactional Outputs
+        alt_id: 402.2.2
+        components:
+          - none
+      - id: 402.2.3
+        handle: Speech Delivery Type and Coordination
+        alt_id: 402.2.3
+        components:
+          - none
+      - id: 402.2.4
+        handle: User Control
+        alt_id: 402.2.4
+        components:
+          - none
+      - id: 402.2.5
+        handle: Braille Instructions
+        alt_id: 402.2.5
+        components:
+          - none
+      - id: 402.3.1
+        handle: Private Listening
+        alt_id: 402.3.1
+        components:
+          - none
+      - id: 402.3.2
+        handle: Non-private Listening
+        alt_id: 402.3.2
+        components:
+          - none
+      - id: "402.4"
+        handle: Characters on Display Screens
+        alt_id: "402.4"
+        components:
+          - none
+      - id: "402.5"
+        handle: Characters on Variable Message Signs
+        alt_id: "402.5"
+        components:
+          - none
+      - id: "403.1"
+        handle: General (Biometrics)
+        alt_id: "403.1"
+        components:
+          - none
+      - id: "404.1"
+        handle: General (Preservation of Information Provided for Accessibility)
+        alt_id: "404.1"
+        components:
+          - none
+      - id: "405.1"
+        handle: General (Privacy)
+        alt_id: "405.1"
+        components:
+          - none
+      - id: "406.1"
+        handle: General (Standard Connections)
+        alt_id: "406.1"
+        components:
+          - none
+      - id: "407.2"
+        handle: Contrast (Operable Parts)
+        alt_id: "407.2"
+        components:
+          - none
+      - id: 407.3.1
+        handle: Tactilely Discernible
+        alt_id: 407.3.1
+        components:
+          - none
+      - id: 407.3.2
+        handle: Alphabetic Keys
+        alt_id: 407.3.2
+        components:
+          - none
+      - id: 407.3.3
+        handle: Numeric Keys
+        alt_id: 407.3.3
+        components:
+          - none
+      - id: "407.4"
+        handle: Key Repeat
+        alt_id: "407.4"
+        components:
+          - none
+      - id: "407.5"
+        handle: Timed Response
+        alt_id: "407.5"
+        components:
+          - none
+      - id: "407.6"
+        handle: Operation
+        alt_id: "407.6"
+        components:
+          - none
+      - id: "407.7"
+        handle: Tickets, Fare Cards, and Keycards
+        alt_id: "407.7"
+        components:
+          - none
+      - id: 407.8.1
+        handle: Vertical Reference Plane
+        alt_id: 407.8.1
+        components:
+          - none
+      - id: 407.8.1.1
+        handle: Vertical Plane for Side Reach
+        alt_id: 407.8.1.1
+        components:
+          - none
+      - id: 407.8.1.2
+        handle: Vertical Plane for Forward Reach
+        alt_id: 407.8.1.2
+        components:
+          - none
+      - id: 407.8.2
+        handle: Side Reach
+        alt_id: 407.8.2
+        components:
+          - none
+      - id: 407.8.2.1
+        handle: Unobstructed Side Reach
+        alt_id: 407.8.2.1
+        components:
+          - none
+      - id: 407.8.2.2
+        handle: Obstructed Side Reach
+        alt_id: 407.8.2.2
+        components:
+          - none
+      - id: 407.8.3
+        handle: Forward Reach
+        alt_id: 407.8.3
+        components:
+          - none
+      - id: 407.8.3.1
+        handle: Unobstructed Forward Reach
+        alt_id: 407.8.3.1
+        components:
+          - none
+      - id: 407.8.3.2
+        handle: Obstructed Forward Reach
+        alt_id: 407.8.3.2
+        components:
+          - none
+      - id: 407.8.3.2.1
+        handle: Operable Part Height for ICT with Obstructed Forward Reach
+        alt_id: 407.8.3.2.1
+        components:
+          - none
+      - id: 407.8.3.2.2
+        handle: Knee and Toe Space under ICT with Obstructed Forward Reach
+        alt_id: 407.8.3.2.2
+        components:
+          - none
+      - id: "408.2"
+        handle: Visibility
+        alt_id: "408.2"
+        components:
+          - none
+      - id: "408.3"
+        handle: Flashing
+        alt_id: "408.3"
+        components:
+          - none
+      - id: "409.1"
+        handle: General (Status Indicators)
+        alt_id: "409.1"
+        components:
+          - none
+      - id: "410.1"
+        handle: General (Color Coding)
+        alt_id: "410.1"
+        components:
+          - none
+      - id: "411.1"
+        handle: General (Audible Signals)
+        alt_id: "411.1"
+        components:
+          - none
+      - id: 412.2.1
+        handle: Volume Gain for Wireline Telephones
+        alt_id: 412.2.1
+        components:
+          - none
+      - id: 412.2.2
+        handle: Volume Gain for Non-Wireline ICT
+        alt_id: 412.2.2
+        components:
+          - none
+      - id: 412.3.1
+        handle: Wireless Handsets
+        alt_id: 412.3.1
+        components:
+          - none
+      - id: 412.3.2
+        handle: Wireline Handsets
+        alt_id: 412.3.2
+        components:
+          - none
+      - id: "412.4"
+        handle: Digital Encoding of Speech
+        alt_id: "412.4"
+        components:
+          - none
+      - id: "412.5"
+        handle: Real-Time Text Functionality
+        alt_id: "412.5"
+        components:
+          - none
+      - id: "412.6"
+        handle: Caller ID
+        alt_id: "412.6"
+        components:
+          - none
+      - id: "412.7"
+        handle: Video Communication
+        alt_id: "412.7"
+        components:
+          - none
+      - id: 412.8.1
+        handle: TTY Connectability
+        alt_id: 412.8.1
+        components:
+          - none
+      - id: 412.8.2
+        handle: Voice and Hearing Carry Over
+        alt_id: 412.8.2
+        components:
+          - none
+      - id: 412.8.3
+        handle: Signal Compatibility
+        alt_id: 412.8.3
+        components:
+          - none
+      - id: 412.8.4
+        handle: Voice Mail and Other Messaging Systems
+        alt_id: 412.8.4
+        components:
+          - none
+      - id: 413.1.1
+        handle: Decoding and Display of Closed Captions
+        alt_id: 413.1.1
+        components:
+          - none
+      - id: 413.1.2
+        handle: Pass-Through of Closed Caption Data
+        alt_id: 413.1.2
+        components:
+          - none
+      - id: 414.1.1
+        handle: Digital Television Tuners
+        alt_id: 414.1.1
+        components:
+          - none
+      - id: 414.1.2
+        handle: Other ICT
+        alt_id: 414.1.2
+        components:
+          - none
+      - id: 415.1.1
+        handle: Caption Controls
+        alt_id: 415.1.1
+        components:
+          - none
+      - id: 415.1.2
+        handle: Audio Description Controls
+        alt_id: 415.1.2
+        components:
+          - none
+  - id: software
+    label: "Chapter 5: Software"
+    order: 5
+    criteria:
+      - id: 502.2.1
+        handle: User Control of Accessibility Features
+        alt_id: 502.2.1
+        components:
+          - none
+      - id: 502.2.2
+        handle: No Disruption of Accessibility Features
+        alt_id: 502.2.2
+        components:
+          - none
+      - id: 502.3.1
+        handle: Object Information
+        alt_id: 502.3.1
+        components:
+          - none
+      - id: 502.3.2
+        handle: Modification of Object Information
+        alt_id: 502.3.2
+        components:
+          - none
+      - id: 502.3.3
+        handle: Row, Column, and Headers
+        alt_id: 502.3.3
+        components:
+          - none
+      - id: 502.3.4
+        handle: Values
+        alt_id: 502.3.4
+        components:
+          - none
+      - id: 502.3.5
+        handle: Modification of Values
+        alt_id: 502.3.5
+        components:
+          - none
+      - id: 502.3.6
+        handle: Label Relationships
+        alt_id: 502.3.6
+        components:
+          - none
+      - id: 502.3.7
+        handle: Hierarchical Relationships
+        alt_id: 502.3.7
+        components:
+          - none
+      - id: 502.3.8
+        handle: Text
+        alt_id: 502.3.8
+        components:
+          - none
+      - id: 502.3.9
+        handle: Modification of Text
+        alt_id: 502.3.9
+        components:
+          - none
+      - id: 502.3.10
+        handle: List of Actions
+        alt_id: 502.3.10
+        components:
+          - none
+      - id: 502.3.11
+        handle: Actions on Objects
+        alt_id: 502.3.11
+        components:
+          - none
+      - id: 502.3.12
+        handle: Focus Cursor
+        alt_id: 502.3.12
+        components:
+          - none
+      - id: 502.3.13
+        handle: Modification of Focus Cursor
+        alt_id: 502.3.13
+        components:
+          - none
+      - id: 502.3.14
+        handle: Event Notification
+        alt_id: 502.3.14
+        components:
+          - none
+      - id: "502.4"
+        handle: Platform Accessibility Features
+        alt_id: "502.4"
+        components:
+          - none
+      - id: "503.2"
+        handle: User Preferences
+        alt_id: "503.2"
+        components:
+          - none
+      - id: "503.3"
+        handle: Alternative User Interfaces
+        alt_id: "503.3"
+        components:
+          - none
+      - id: 503.4.1
+        handle: Caption Controls
+        alt_id: 503.4.1
+        components:
+          - none
+      - id: 503.4.2
+        handle: Audio Description Controls
+        alt_id: 503.4.2
+        components:
+          - none
+      - id: 504.2.1
+        handle: >-
+          Preservation of Information Provided for Accessibility in Format
+          Conversion
+        alt_id: 504.2.1
+        components:
+          - none
+      - id: 504.2.2
+        handle: PDF Export
+        alt_id: 504.2.2
+        components:
+          - none
+      - id: "504.3"
+        handle: Prompts
+        alt_id: "504.3"
+        components:
+          - none
+      - id: "504.4"
+        handle: Templates
+        alt_id: "504.4"
+        components:
+          - none
+  - id: support_documentation_and_services
+    label: "Chapter 6: Support Documentation and Services"
+    order: 6
+    criteria:
+      - id: "602.2"
+        handle: Accessibility and Compatibility Features
+        alt_id: "602.2"
+        components:
+          - none
+      - id: "602.4"
+        handle: Alternate Formats for Non-Electronic Support Documentation
+        alt_id: "602.4"
+        components:
+          - none
+      - id: "603.2"
+        handle: Information on Accessibility and Compatibility Features
+        alt_id: "603.2"
+        components:
+          - none
+      - id: "603.3"
+        handle: Accommodation of Communication Needs
+        alt_id: "603.3"
+        components:
+          - none
+components:
+  - id: web
+    label: Web
+  - id: electronic-docs
+    label: Electronic Docs
+  - id: software
+    label: Software
+  - id: authoring-tool
+    label: Authoring Tool
+  - id: none
+    label: ""
+terms:
+  - id: supports
+    label: Supports
+    description: >-
+      The functionality of the product has at least one method that meets the
+      criterion without known defects or meets with equivalent facilitation.
+  - id: partially-supports
+    label: Partially Supports
+    description: Some functionality of the product does not meet the criterion.
+  - id: does-not-support
+    label: Does Not Support
+    description: The majority of product functionality does not meet the criterion.
+  - id: not-applicable
+    label: Not Applicable
+    description: The criterion is not relevant to the product.
+  - id: not-evaluated
+    label: Not Evaluated
+    description: >-
+      The product has not been evaluated against the criterion. This can be used
+      only in WCAG 2.0 Level AAA.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,0 +1,3 @@
+**Note**: The catalogs in here are auto-generated using the librarian utility in the OPATs repo.
+
+See [catalogs section in CLI documentation](https://github.com/GSA/open-product-accessibility-template/blob/main/docs/CLI.md#catalogs) and [Librarian documentation](https://github.com/GSA/open-product-accessibility-template/blob/main/docs/Librarian.md).

--- a/opat/README.md
+++ b/opat/README.md
@@ -1,0 +1,3 @@
+Current list of OPATs.
+
+See also [OPAT section in CLI documentation](https://github.com/GSA/open-product-accessibility-template/blob/main/docs/CLI.md#opats).

--- a/opat/custom.css
+++ b/opat/custom.css
@@ -1,0 +1,1 @@
+/* Add custom CSS in here */

--- a/opat/drupal-9.html
+++ b/opat/drupal-9.html
@@ -1,0 +1,1621 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Drupal Accessibility Conformance Report</title>
+  <link rel="stylesheet" href="opat.css">
+  <link rel="stylesheet" href="custom.css">
+</head>
+<body>
+  <header>
+    <h1>Drupal Accessibility Conformance Report</h1>
+
+    Based on VPAT® 2.4 Revised Section 508 Edition
+  </header>
+  <main>
+    <h2 id="name-of-product-version">
+      <a href="#name-of-product-version" aria-hidden="true" class="header-anchor">#</a>
+      Name of Product/Version
+    </h2>
+    Drupal 9.1
+
+    <h2 id="report-date">
+      <a href="#report-date" aria-hidden="true" class="header-anchor">#</a>
+      Report Date
+    </h2>
+    8/19/2021
+
+      <h2 id="product-description">
+        <a href="#product-description" aria-hidden="true" class="header-anchor">#</a>
+        Product Description
+      </h2>
+      Content Management System
+
+    <h2 id="contact-information">
+      <a href="#contact-information" aria-hidden="true" class="header-anchor">#</a>
+      Contact Information
+    </h2>
+      <h3 id="author">
+        <a href="#author" aria-hidden="true" class="header-anchor">#</a>
+        Author Information
+      </h3>
+      <ul>
+        <li>Name: Mike Gifford</li>
+        <li>Company: CivicActions</li>
+        <li>Address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549</li>
+        <li>Email: <a href="mailto:mike.gifford@civicactions.com">mike.gifford@civicactions.com</a></li>
+        <li>Phone: (510) 408-7510</li>
+        <li>Website: <a href="https://civicactions.com/">https://civicactions.com/</a></li>
+      </ul>
+
+      <h2 id="notes">
+        <a href="#notes" aria-hidden="true" class="header-anchor">#</a>
+        Notes
+      </h2>
+      Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+
+      <h2 id="evaluation-methods">
+        <a href="#evaluation-methods" aria-hidden="true" class="header-anchor">#</a>
+        Evaluation Methods Used
+      </h2>
+      Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+
+    <h2 id="applicable-standards-guidelines">
+      <a href="#applicable-standards-guidelines" aria-hidden="true" class="header-anchor">#</a>
+      Applicable Standards/Guidelines
+    </h2>
+    This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+    <table>
+      <thead>
+        <tr>
+          <th>Standard/Guideline</th>
+          <th>Included In Report</th>
+        </tr>
+      </thead>
+      <tbody>
+          <tr>
+            <td><a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a></td>
+            <td><ul><li>Table 1: Success Criteria, Level A</li><li>Table 2: Success Criteria, Level AA</li><li>Table 3: Success Criteria, Level AAA</li></ul></td>
+          </tr>
+          <tr>
+            <td><a href="https://www.access-board.gov/ict/">Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018</a></td>
+            <td><ul><li>Chapter 3: Functional Performance Criteria (FPC)</li><li>Chapter 4: Hardware</li><li>Chapter 5: Software</li><li>Chapter 6: Support Documentation and Services</li></ul></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <h2 id="terms">
+      <a href="#terms" aria-hidden="true" class="header-anchor">#</a>
+      Terms
+    </h2>
+    The terms used in the Conformance Level information are defined as follows:
+    <ul>
+      <li><strong>Supports</strong>: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.</li>
+      <li><strong>Partially Supports</strong>: Some functionality of the product does not meet the criterion.</li>
+      <li><strong>Does Not Support</strong>: The majority of product functionality does not meet the criterion.</li>
+      <li><strong>Not Applicable</strong>: The criterion is not relevant to the product.</li>
+      <li><strong>Not Evaluated</strong>: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.</li>
+    </ul>
+
+      <h2 id="wcag-2.0">
+        <a href="#wcag-2.0" aria-hidden="true" class="header-anchor">#</a>
+        WCAG 2.0 Report
+      </h2>
+          <h3 id="success_criteria_level_a">
+            <a href="#success_criteria_level_a" aria-hidden="true" class="header-anchor">#</a>
+            Table 1: Success Criteria, Level A
+          </h3>
+
+              Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp; back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation.
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr id="1.1.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
+                          1.1.1 Non-text Content
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal 8 requires alt text for images by default.</li>
+                              <li><strong>Electronic Docs</strong>: Some non-textual content in the documentation does not provide a textual alternative.</li>
+                              <li><strong>Authoring Tool</strong>: The back end of Drupal Core was built to be  WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue 3002770.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt">
+                          1.2.1 Audio-only and Video-only (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.</li>
+                              <li><strong>Electronic Docs</strong>: This is not explicitly defined in the documentation.</li>
+                              <li><strong>Authoring Tool</strong>: There is no additional support for authors within the authoring interface to explain how this can be done.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
+                          1.2.2 Captions (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The file module in Core lets authors upload audio and video content, and output &lt;audio&gt; and &lt;video&gt; elements and does not support captions.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal does not support, let alone require users to include captions. Hard coding open captions is presently the only way to satisfy this in Core.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">
+                          1.2.3 Audio Description or Media Alternative (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Audio files can be uploaded, but there is no way to associate captions in Core.</li>
+                              <li><strong>Electronic Docs</strong>: There is no documentation on how to properly convey pre-recorded audio descriptions.</li>
+                              <li><strong>Authoring Tool</strong>: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.3.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">
+                          1.3.1 Info and Relationships
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Information is structured into logical relationships. Navigational lists are well used to group information. Forms have a visual and semantic representation for required fields. Message windows have ARIA role defined incorrectly as role&#x3D;contentinfo which impacts content relationships - Drupal issue 2942404. aria-live announcement is not contained in a landmark - Drupal issue 3098857.</li>
+                              <li><strong>Electronic Docs</strong>: Information is structured into logical relationships. Navigational lists are well used to group information.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.3.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">
+                          1.3.2 Meaningful Sequence
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal Core has been extensively tested with keyboard only users. As a proudly multilingual CMS, Drupal provides support for bidirectional navigation.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.3.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding">
+                          1.3.3 Sensory Characteristics
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Where possible Drupal Core uses combinations of text and symbols for the user interface.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring interface has been developed to not rely on symbols alone to convey information to the user.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color">
+                          1.4.1 Use of Color
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Color is not used without text and often symbols to convey meaning.</li>
+                              <li><strong>Authoring Tool</strong>: In general, the admin theme is very accessible. The Claro Administration Theme shortcut start needs improvement - Drupal issue 3171726.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio">
+                          1.4.2 Audio Control
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.1.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable">
+                          2.1.1 Keyboard
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Users can interact with Drupal Core with the keyboard and without specific timings for individual keystrokes.</li>
+                              <li><strong>Authoring Tool</strong>: Authors are largely able to engage with Drupal Core with the keyboard and without specific timings for individual keystrokes. Tooltips not displayed for keyboard navigation - Drupal issue 2933984. There are reported issues with IE11 and JAWS - Drupal issue 2852702. It is worth noting that Drupal&#x27;s admin is powerful and complex, and there are other accessibility reports in the issue queue.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.1.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping">
+                          2.1.2 No Keyboard Trap
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focus can be moved away from that component using only a keyboard interface.</li>
+                              <li><strong>Authoring Tool</strong>: Focus can be moved away from that component using only a keyboard interface.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.2.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors">
+                          2.2.1 Pause, Stop, Hide
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The time limit is longer than 20 hours.</li>
+                              <li><strong>Authoring Tool</strong>: The time limit is longer than 20 hours.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.2.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-pause">
+                          2.2.2 Timing Adjustable
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.3.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate">
+                          2.3.1 Three Flashes or Below Threshold
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no flashing elements in Drupal Core.</li>
+                              <li><strong>Authoring Tool</strong>: There are no flashing elements in Drupal Core.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip">
+                          2.4.1 Bypass Blocks
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Skip links are provided.</li>
+                              <li><strong>Electronic Docs</strong>: Skip links are provided.</li>
+                              <li><strong>Authoring Tool</strong>: Skip links are provided.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">
+                          2.4.2 Page Titled
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li>
+                              <li><strong>Authoring Tool</strong>: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order">
+                          2.4.3 Focus Order
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                              <li><strong>Electronic Docs</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                              <li><strong>Authoring Tool</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs">
+                          2.4.4 Link Purpose (In Context)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li>
+                              <li><strong>Authoring Tool</strong>: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id">
+                          3.1.1 Language of Page
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Page language is defined semantically on every page.</li>
+                              <li><strong>Electronic Docs</strong>: Page language is defined semantically on every page.</li>
+                              <li><strong>Authoring Tool</strong>: Page language is defined semantically on every page.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.2.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus">
+                          3.2.1 On Focus
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                              <li><strong>Electronic Docs</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                              <li><strong>Authoring Tool</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.2.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change">
+                          3.2.2 On Input
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                              <li><strong>Electronic Docs</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                              <li><strong>Authoring Tool</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified">
+                          3.3.1 Error Identification
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li>
+                              <li><strong>Authoring Tool</strong>: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues">
+                          3.3.2 Labels or Instructions
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Default forms all include labels.</li>
+                              <li><strong>Authoring Tool</strong>: There are a few places where there are problems with labels, but these are odd exceptions - Drupal issue 3015494.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="4.1.1">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses">
+                          4.1.1 Parsing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li>
+                              <li><strong>Electronic Docs</strong>: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li>
+                              <li><strong>Authoring Tool</strong>: Generally parsing is very well supported, but there are a few places where this needs to be improved - Drupal issue 1852090 and 3144948.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="4.1.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv">
+                          4.1.2 Name, Role, Value
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Public pages support this criterion.</li>
+                              <li><strong>Electronic Docs</strong>: Public pages support this criterion.</li>
+                              <li><strong>Authoring Tool</strong>: This is generally well supported, but there are places where it has been overlooked. Drupal issue 3144948, 3019487, and 3085545.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+          <h3 id="success_criteria_level_aa">
+            <a href="#success_criteria_level_aa" aria-hidden="true" class="header-anchor">#</a>
+            Table 2: Success Criteria, Level AA
+          </h3>
+
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr id="1.2.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions">
+                          1.2.4 Captions (Live)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only">
+                          1.2.5 Audio Description (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Audio files can be uploaded, but there is no way to associate captions in Core.</li>
+                              <li><strong>Electronic Docs</strong>: There is no documentation on how to properly convey pre-recorded audio descriptions.</li>
+                              <li><strong>Authoring Tool</strong>: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">
+                          1.4.3 Contrast (Minimum)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally meets. Some contrast failures around grey backgrounds - Drupal issue 3040673.</li>
+                              <li><strong>Electronic Docs</strong>: The docs have sufficient contrast.</li>
+                              <li><strong>Authoring Tool</strong>: Generally meets requirements. Some challenges with Core admin themes - Drupal issue 930508 and 3080100.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale">
+                          1.4.4 Resize text
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally support with some minor exceptions - Drupal issue 3129257.</li>
+                              <li><strong>Electronic Docs</strong>: The docs are accessible up to 200%.</li>
+                              <li><strong>Authoring Tool</strong>: Generally good with some exceptions - Drupal issue 3164587.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation">
+                          1.4.5 Images of Text
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Authoring Tool</strong>: Text is generally styled with CSS in the authoring tool. Should images of text be uploaded by the user, they will be required to add alternative text.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc">
+                          2.4.5 Multiple Ways
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                              <li><strong>Electronic Docs</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                              <li><strong>Authoring Tool</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.6">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive">
+                          2.4.6 Headings and Labels
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally there is very good support. Some heading levels may be missed in some unique contexts - Drupal issue 1768732. Better support could be provided for threaded comments - Drupal issue 2290043.</li>
+                              <li><strong>Authoring Tool</strong>: Generally good, but for dynamic elements like the Layout Builder need a plan for a dynamic heading structure - Drupal issue 3007978.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.7">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible">
+                          2.4.7 Focus Visible
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focus elements are well established for the front-end. Further enhancements are being developed to make it more obvious for keyboard only users.</li>
+                              <li><strong>Authoring Tool</strong>: An IE specific bug where there are focus issues for authors and administrators in the Claro theme - Drupal issue 3048785.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id">
+                          3.1.2 Language of Parts
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Multilingual sites have language switchers with proper semantics. Unfotunately support is lacking for multi-lingual search 2992894 as well as both the Filesystem 3163915 &amp; Views components 2496223.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal has good support for multilingual content and accessibility. To support the Language of Parts for authors, a button can be added to simplify the process of adding language specific phrases.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.2.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations">
+                          3.2.3 Consistent Navigation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                              <li><strong>Electronic Docs</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.2.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality">
+                          3.2.4 Consistent Identification
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                              <li><strong>Electronic Docs</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                              <li><strong>Authoring Tool</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions">
+                          3.3.3 Error Suggestion
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li>
+                              <li><strong>Authoring Tool</strong>: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible">
+                          3.3.4 Error Prevention (Legal, Financial, Data)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: By default users can editing content which they own.</li>
+                              <li><strong>Electronic Docs</strong>: Documentation could be improved.</li>
+                              <li><strong>Authoring Tool</strong>: There is nothing to differentiate editing financial or legal data from any other data managed by Drupal.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+          <h3 id="success_criteria_level_aaa">
+            <a href="#success_criteria_level_aaa" aria-hidden="true" class="header-anchor">#</a>
+            Table 3: Success Criteria, Level AAA
+          </h3>
+
+              Notes: Where possible the Drupal community strives to exceed AA compliance.
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr id="1.2.6">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign">
+                          1.2.6 Sign Language (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.7">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad">
+                          1.2.7 Extended Audio Description (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.8">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc">
+                          1.2.8 Media Alternative (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.2.9">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only">
+                          1.2.9 Audio-only (Live)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.6">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">
+                          1.4.6 Contrast (Enhanced)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: A front-end and back-end theme could be configured to allow this to comply.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.7">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio">
+                          1.4.7 Low or No Background Audio
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.8">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation">
+                          1.4.8 Visual Presentation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Evaluated</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Stable Core themes leave much of the presentation of text to user agents, so aside from line spacing this generally works.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="1.4.9">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images">
+                          1.4.9 Images of Text (No Exception)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Text images are all supplied by the author.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.1.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs">
+                          2.1.3 Keyboard (No Exception)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The web front-end is not a barrier to keyboard only users.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.2.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions">
+                          2.2.3 No Timing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no timeouts in Drupal Core that would affect people with disabilities.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.2.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed">
+                          2.2.4 Interruptions
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.2.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout">
+                          2.2.5 Re-authenticating
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.3.2">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#seizure-three-times">
+                          2.3.2 Three Flashes
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is no flashing content.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.8">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location">
+                          2.4.8 Location
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Breadcrumbs are available and sitemap modules can be added to provide additional means for navigation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.9">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link">
+                          2.4.9 Link Purpose (Link Only)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is a mechanism to support automated links with semantic descriptive titles.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="2.4.10">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings">
+                          2.4.10 Section Headings
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal provides heading elements at the beginning of each section of content.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.3">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-idioms">
+                          3.1.3 Unusual Words
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.4">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-located">
+                          3.1.4 Abbreviations
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-supplements">
+                          3.1.5 Reading Level
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.1.6">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation">
+                          3.1.6 Pronunciation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.2.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context">
+                          3.2.5 Change on Request
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.5">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help">
+                          3.3.5 Help
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="3.3.6">
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all">
+                          3.3.6 Error Prevention (All)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+      <h2 id="508">
+        <a href="#508" aria-hidden="true" class="header-anchor">#</a>
+        Revised Section 508 Report
+      </h2>
+          <h3 id="functional_performance_criteria">
+            <a href="#functional_performance_criteria" aria-hidden="true" class="header-anchor">#</a>
+            Chapter 3: Functional Performance Criteria (FPC)
+          </h3>
+
+              Notes: Not applicable.
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr id="302.1">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.1">
+                          302.1 Without Vision
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Testing has been done with JAWS, NVDA and VoiceOver.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.2">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.2">
+                          302.2 With Limited Vision
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Testing has been done with browser zoom and ZoomText.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.3">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.3">
+                          302.3 Without Perception of Color
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>The interface has been reviewed for use of color.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.4">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.4">
+                          302.4 Without Hearing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.5">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.5">
+                          302.5 With Limited Hearing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.6">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.6">
+                          302.6 Without Speech
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.7">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.7">
+                          302.7 With Limited Manipulation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Drupal&#x27;s interface does not restrict users with limited manipulation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.8">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.8">
+                          302.8 With Limited Reach and Strength
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Drupal&#x27;s interface does not restrict users with limited reach or strength.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="302.9">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.9">
+                          302.9 With Limited Language, Cognitive, and Learning Abilities
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+          <h3 id="hardware">
+            <a href="#hardware" aria-hidden="true" class="header-anchor">#</a>
+            Chapter 4: Hardware
+          </h3>
+
+              Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
+
+          <h3 id="software">
+            <a href="#software" aria-hidden="true" class="header-anchor">#</a>
+            Chapter 5: Software
+          </h3>
+
+              Notes: Drupal is a web application. Software accessibility criteria is not applicable.
+
+          <h3 id="support_documentation_and_services">
+            <a href="#support_documentation_and_services" aria-hidden="true" class="header-anchor">#</a>
+            Chapter 6: Support Documentation and Services
+          </h3>
+
+              Notes: Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr id="602.2">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#602.2">
+                          602.2 Accessibility and Compatibility Features
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="602.4">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#602.4">
+                          602.4 Alternate Formats for Non-Electronic Support Documentation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="603.2">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#603.2">
+                          603.2 Information on Accessibility and Compatibility Features
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr id="603.3">
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#603.3">
+                          603.3 Accommodation of Communication Needs
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+      <h2>Legal Disclaimer</h2>
+      The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
+  </main>
+  <footer>
+    <p><a href="https://github.com/GSA/open-product-accessibility-template">OPAT</a> is a format maintained by the <a href="https://gsa.gov/">GSA</a>. The content is the responsibility of the author.</p>
+  </footer>
+</body>
+</html>

--- a/opat/drupal-9.markdown
+++ b/opat/drupal-9.markdown
@@ -1,0 +1,165 @@
+# Drupal Accessibility Conformance Report
+
+Based on VPAT® 2.4 Revised Section 508 Edition
+
+## Name of Product/Version
+Drupal 9.1
+
+## Report Date
+8/16/2021
+
+## Product Description
+Content Management System
+
+## Contact Information
+### Author Information
+- Name: Mike Gifford
+- Company: CivicActions
+- Address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549
+- Email: mike.gifford@civicactions.com
+- Phone: (510) 408-7510
+- Website: https://civicactions.com/
+
+## Notes
+Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+
+## Evaluation Methods Used
+Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+
+## Applicable Standards/Guidelines
+This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+| Standard/Guideline | Included In Report |
+| --- | --- |
+| [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/) | <ul><li>Table 1: Success Criteria, Level A</li><li>Table 2: Success Criteria, Level AA</li><li>Table 3: Success Criteria, Level AAA</li></ul> |
+| [Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018](https://www.access-board.gov/ict/) | <ul><li>Chapter 3: Functional Performance Criteria (FPC)</li><li>Chapter 4: Hardware</li><li>Chapter 5: Software</li><li>Chapter 6: Support Documentation and Services</li></ul> |
+
+## Terms
+The terms used in the Conformance Level information are defined as follows:
+- **Supports**: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.
+- **Partially Supports**: Some functionality of the product does not meet the criterion.
+- **Does Not Support**: The majority of product functionality does not meet the criterion.
+- **Not Applicable**: The criterion is not relevant to the product.
+- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
+
+## WCAG 2.0 Report
+### Table 1: Success Criteria, Level A
+
+Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp; back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation.
+
+| Criteria | Conformance Level | Remarks and Explanations |
+| --- | --- | --- |
+| [1.1.1 Non-text Content](https://www.w3.org/TR/WCAG20/#text-equiv-all) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Drupal 8 requires alt text for images by default.</li><li>**Electronic Docs**: Some non-textual content in the documentation does not provide a textual alternative.</li><li>**Authoring Tool**: The back end of Drupal Core was built to be  WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue 3002770.</li> </ul> |
+| [1.2.1 Audio-only and Video-only (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.</li><li>**Electronic Docs**: This is not explicitly defined in the documentation.</li><li>**Authoring Tool**: There is no additional support for authors within the authoring interface to explain how this can be done.</li> </ul> |
+| [1.2.2 Captions (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-captions) | <ul><li>**Web**: Does Not Support</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Does Not Support</li> </ul> | <ul><li>**Web**: The file module in Core lets authors upload audio and video content, and output &lt;audio&gt; and &lt;video&gt; elements and does not support captions.</li><li>**Authoring Tool**: Drupal does not support, let alone require users to include captions. Hard coding open captions is presently the only way to satisfy this in Core.</li> </ul> |
+| [1.2.3 Audio Description or Media Alternative (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc) | <ul><li>**Web**: Does Not Support</li><li>**Electronic Docs**: Does Not Support</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Does Not Support</li> </ul> | <ul><li>**Web**: Audio files can be uploaded, but there is no way to associate captions in Core.</li><li>**Electronic Docs**: There is no documentation on how to properly convey pre-recorded audio descriptions.</li><li>**Authoring Tool**: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li> </ul> |
+| [1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Information is structured into logical relationships. Navigational lists are well used to group information. Forms have a visual and semantic representation for required fields. Message windows have ARIA role defined incorrectly as role&#x3D;contentinfo which impacts content relationships - Drupal issue 2942404. aria-live announcement is not contained in a landmark - Drupal issue 3098857.</li><li>**Electronic Docs**: Information is structured into logical relationships. Navigational lists are well used to group information.</li><li>**Authoring Tool**: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li> </ul> |
+| [1.3.2 Meaningful Sequence](https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Drupal Core has been extensively tested with keyboard only users. As a proudly multilingual CMS, Drupal provides support for bidirectional navigation.</li><li>**Authoring Tool**: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li> </ul> |
+| [1.3.3 Sensory Characteristics](https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Where possible Drupal Core uses combinations of text and symbols for the user interface.</li><li>**Authoring Tool**: The authoring interface has been developed to not rely on symbols alone to convey information to the user.</li> </ul> |
+| [1.4.1 Use of Color](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Color is not used without text and often symbols to convey meaning.</li><li>**Authoring Tool**: In general, the admin theme is very accessible. The Claro Administration Theme shortcut start needs improvement - Drupal issue 3171726.</li> </ul> |
+| [1.4.2 Audio Control](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio) | <ul><li>**Web**: Not Applicable</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Not Applicable</li> </ul> | <ul> </ul> |
+| [2.1.1 Keyboard](https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: Users can interact with Drupal Core with the keyboard and without specific timings for individual keystrokes.</li><li>**Authoring Tool**: Authors are largely able to engage with Drupal Core with the keyboard and without specific timings for individual keystrokes. Tooltips not displayed for keyboard navigation - Drupal issue 2933984. There are reported issues with IE11 and JAWS - Drupal issue 2852702. It is worth noting that Drupal&#x27;s admin is powerful and complex, and there are other accessibility reports in the issue queue.</li> </ul> |
+| [2.1.2 No Keyboard Trap](https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Focus can be moved away from that component using only a keyboard interface.</li><li>**Authoring Tool**: Focus can be moved away from that component using only a keyboard interface.</li> </ul> |
+| [2.2.1 Pause, Stop, Hide](https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: The time limit is longer than 20 hours.</li><li>**Authoring Tool**: The time limit is longer than 20 hours.</li> </ul> |
+| [2.2.2 Timing Adjustable](https://www.w3.org/TR/WCAG20/#time-limits-pause) | <ul><li>**Web**: Not Applicable</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Not Applicable</li> </ul> | <ul> </ul> |
+| [2.3.1 Three Flashes or Below Threshold](https://www.w3.org/TR/WCAG20/#seizure-does-not-violate) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: There are no flashing elements in Drupal Core.</li><li>**Authoring Tool**: There are no flashing elements in Drupal Core.</li> </ul> |
+| [2.4.1 Bypass Blocks](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Skip links are provided.</li><li>**Electronic Docs**: Skip links are provided.</li><li>**Authoring Tool**: Skip links are provided.</li> </ul> |
+| [2.4.2 Page Titled](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li><li>**Authoring Tool**: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li> </ul> |
+| [2.4.3 Focus Order](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Focusable components receive focus in an order that preserves meaning and operability.</li><li>**Electronic Docs**: Focusable components receive focus in an order that preserves meaning and operability.</li><li>**Authoring Tool**: Focusable components receive focus in an order that preserves meaning and operability.</li> </ul> |
+| [2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li><li>**Authoring Tool**: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li> </ul> |
+| [3.1.1 Language of Page](https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Page language is defined semantically on every page.</li><li>**Electronic Docs**: Page language is defined semantically on every page.</li><li>**Authoring Tool**: Page language is defined semantically on every page.</li> </ul> |
+| [3.2.1 On Focus](https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Change in the focus state does not initiate a change of context for the user.</li><li>**Electronic Docs**: Change in the focus state does not initiate a change of context for the user.</li><li>**Authoring Tool**: Change in the focus state does not initiate a change of context for the user.</li> </ul> |
+| [3.2.2 On Input](https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Engaging with the interactive sites does not unexpectedly take control from the users.</li><li>**Electronic Docs**: Engaging with the interactive sites does not unexpectedly take control from the users.</li><li>**Authoring Tool**: Engaging with the interactive sites does not unexpectedly take control from the users.</li> </ul> |
+| [3.3.1 Error Identification](https://www.w3.org/TR/WCAG20/#minimize-error-identified) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li><li>**Authoring Tool**: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li> </ul> |
+| [3.3.2 Labels or Instructions](https://www.w3.org/TR/WCAG20/#minimize-error-cues) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: Default forms all include labels.</li><li>**Authoring Tool**: There are a few places where there are problems with labels, but these are odd exceptions - Drupal issue 3015494.</li> </ul> |
+| [4.1.1 Parsing](https://www.w3.org/TR/WCAG20/#ensure-compat-parses) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li><li>**Electronic Docs**: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li><li>**Authoring Tool**: Generally parsing is very well supported, but there are a few places where this needs to be improved - Drupal issue 1852090 and 3144948.</li> </ul> |
+| [4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG20/#ensure-compat-rsv) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Public pages support this criterion.</li><li>**Electronic Docs**: Public pages support this criterion.</li><li>**Authoring Tool**: This is generally well supported, but there are places where it has been overlooked. Drupal issue 3144948, 3019487, and 3085545.</li> </ul> |
+
+### Table 2: Success Criteria, Level AA
+
+
+| Criteria | Conformance Level | Remarks and Explanations |
+| --- | --- | --- |
+| [1.2.4 Captions (Live)](https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions) | <ul><li>**Web**: Not Applicable</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.2.5 Audio Description (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only) | <ul><li>**Web**: Does Not Support</li><li>**Electronic Docs**: Does Not Support</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Does Not Support</li> </ul> | <ul><li>**Web**: Audio files can be uploaded, but there is no way to associate captions in Core.</li><li>**Electronic Docs**: There is no documentation on how to properly convey pre-recorded audio descriptions.</li><li>**Authoring Tool**: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li> </ul> |
+| [1.4.3 Contrast (Minimum)](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Generally meets. Some contrast failures around grey backgrounds - Drupal issue 3040673.</li><li>**Electronic Docs**: The docs have sufficient contrast.</li><li>**Authoring Tool**: Generally meets requirements. Some challenges with Core admin themes - Drupal issue 930508 and 3080100.</li> </ul> |
+| [1.4.4 Resize text](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: Generally support with some minor exceptions - Drupal issue 3129257.</li><li>**Electronic Docs**: The docs are accessible up to 200%.</li><li>**Authoring Tool**: Generally good with some exceptions - Drupal issue 3164587.</li> </ul> |
+| [1.4.5 Images of Text](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation) | <ul><li>**Web**: Not Applicable</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Authoring Tool**: Text is generally styled with CSS in the authoring tool. Should images of text be uploaded by the user, they will be required to add alternative text.</li> </ul> |
+| [2.4.5 Multiple Ways](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: There is more than one way to locate a Web page within the CMS.</li><li>**Electronic Docs**: There is more than one way to locate a Web page within the CMS.</li><li>**Authoring Tool**: There is more than one way to locate a Web page within the CMS.</li> </ul> |
+| [2.4.6 Headings and Labels](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: Generally there is very good support. Some heading levels may be missed in some unique contexts - Drupal issue 1768732. Better support could be provided for threaded comments - Drupal issue 2290043.</li><li>**Authoring Tool**: Generally good, but for dynamic elements like the Layout Builder need a plan for a dynamic heading structure - Drupal issue 3007978.</li> </ul> |
+| [2.4.7 Focus Visible](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: Focus elements are well established for the front-end. Further enhancements are being developed to make it more obvious for keyboard only users.</li><li>**Authoring Tool**: An IE specific bug where there are focus issues for authors and administrators in the Claro theme - Drupal issue 3048785.</li> </ul> |
+| [3.1.2 Language of Parts](https://www.w3.org/TR/WCAG20/#meaning-other-lang-id) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Multilingual sites have language switchers with proper semantics. Unfotunately support is lacking for multi-lingual search 2992894 as well as both the Filesystem 3163915 &amp; Views components 2496223.</li><li>**Authoring Tool**: Drupal has good support for multilingual content and accessibility. To support the Language of Parts for authors, a button can be added to simplify the process of adding language specific phrases.</li> </ul> |
+| [3.2.3 Consistent Navigation](https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li><li>**Electronic Docs**: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li><li>**Authoring Tool**: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li> </ul> |
+| [3.2.4 Consistent Identification](https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Components in Drupal that have the same functionality are identified consistently.</li><li>**Electronic Docs**: Components in Drupal that have the same functionality are identified consistently.</li><li>**Authoring Tool**: Components in Drupal that have the same functionality are identified consistently.</li> </ul> |
+| [3.3.3 Error Suggestion](https://www.w3.org/TR/WCAG20/#minimize-error-suggestions) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li><li>**Authoring Tool**: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li> </ul> |
+| [3.3.4 Error Prevention (Legal, Financial, Data)](https://www.w3.org/TR/WCAG20/#minimize-error-reversible) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: By default users can editing content which they own.</li><li>**Electronic Docs**: Documentation could be improved.</li><li>**Authoring Tool**: There is nothing to differentiate editing financial or legal data from any other data managed by Drupal.</li> </ul> |
+
+### Table 3: Success Criteria, Level AAA
+
+Notes: Where possible the Drupal community strives to exceed AA compliance.
+
+| Criteria | Conformance Level | Remarks and Explanations |
+| --- | --- | --- |
+| [1.2.6 Sign Language (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-sign) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.2.7 Extended Audio Description (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.2.8 Media Alternative (Prerecorded)](https://www.w3.org/TR/WCAG20/#media-equiv-text-doc) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.2.9 Audio-only (Live)](https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.4.6 Contrast (Enhanced)](https://www.w3.org/TR/WCAG20/#visual-audio-contrast7) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: A front-end and back-end theme could be configured to allow this to comply.</li> </ul> |
+| [1.4.7 Low or No Background Audio](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [1.4.8 Visual Presentation](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation) | <ul><li>**Web**: Not Evaluated</li> </ul> | <ul><li>**Web**: Stable Core themes leave much of the presentation of text to user agents, so aside from line spacing this generally works.</li> </ul> |
+| [1.4.9 Images of Text (No Exception)](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: Text images are all supplied by the author.</li> </ul> |
+| [2.1.3 Keyboard (No Exception)](https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: The web front-end is not a barrier to keyboard only users.</li> </ul> |
+| [2.2.3 No Timing](https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: There are no timeouts in Drupal Core that would affect people with disabilities.</li> </ul> |
+| [2.2.4 Interruptions](https://www.w3.org/TR/WCAG20/#time-limits-postponed) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [2.2.5 Re-authenticating](https://www.w3.org/TR/WCAG20/#time-limits-server-timeout) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [2.3.2 Three Flashes](https://www.w3.org/TR/WCAG20/#seizure-three-times) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: There is no flashing content.</li> </ul> |
+| [2.4.8 Location](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: Breadcrumbs are available and sitemap modules can be added to provide additional means for navigation.</li> </ul> |
+| [2.4.9 Link Purpose (Link Only)](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link) | <ul><li>**Web**: Partially Supports</li> </ul> | <ul><li>**Web**: There is a mechanism to support automated links with semantic descriptive titles.</li> </ul> |
+| [2.4.10 Section Headings](https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings) | <ul><li>**Web**: Supports</li> </ul> | <ul><li>**Web**: Drupal provides heading elements at the beginning of each section of content.</li> </ul> |
+| [3.1.3 Unusual Words](https://www.w3.org/TR/WCAG20/#meaning-idioms) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.1.4 Abbreviations](https://www.w3.org/TR/WCAG20/#meaning-located) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.1.5 Reading Level](https://www.w3.org/TR/WCAG20/#meaning-supplements) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.1.6 Pronunciation](https://www.w3.org/TR/WCAG20/#meaning-pronunciation) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.2.5 Change on Request](https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.3.5 Help](https://www.w3.org/TR/WCAG20/#minimize-error-context-help) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+| [3.3.6 Error Prevention (All)](https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
+
+## Revised Section 508 Report
+### Chapter 3: Functional Performance Criteria (FPC)
+
+Notes: Not applicable.
+
+| Criteria | Conformance Level | Remarks and Explanations |
+| --- | --- | --- |
+| [302.1 Without Vision](https://www.access-board.gov/ict/#302.1) | <ul><li>Supports</li> </ul> | <ul><li>Testing has been done with JAWS, NVDA and VoiceOver.</li> </ul> |
+| [302.2 With Limited Vision](https://www.access-board.gov/ict/#302.2) | <ul><li>Supports</li> </ul> | <ul><li>Testing has been done with browser zoom and ZoomText.</li> </ul> |
+| [302.3 Without Perception of Color](https://www.access-board.gov/ict/#302.3) | <ul><li>Supports</li> </ul> | <ul><li>The interface has been reviewed for use of color.</li> </ul> |
+| [302.4 Without Hearing](https://www.access-board.gov/ict/#302.4) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [302.5 With Limited Hearing](https://www.access-board.gov/ict/#302.5) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [302.6 Without Speech](https://www.access-board.gov/ict/#302.6) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [302.7 With Limited Manipulation](https://www.access-board.gov/ict/#302.7) | <ul><li>Supports</li> </ul> | <ul><li>Drupal&#x27;s interface does not restrict users with limited manipulation.</li> </ul> |
+| [302.8 With Limited Reach and Strength](https://www.access-board.gov/ict/#302.8) | <ul><li>Supports</li> </ul> | <ul><li>Drupal&#x27;s interface does not restrict users with limited reach or strength.</li> </ul> |
+| [302.9 With Limited Language, Cognitive, and Learning Abilities](https://www.access-board.gov/ict/#302.9) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+
+### Chapter 4: Hardware
+
+Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
+
+### Chapter 5: Software
+
+Notes: Drupal is a web application. Software accessibility criteria is not applicable.
+
+### Chapter 6: Support Documentation and Services
+
+Notes: Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
+
+| Criteria | Conformance Level | Remarks and Explanations |
+| --- | --- | --- |
+| [602.2 Accessibility and Compatibility Features](https://www.access-board.gov/ict/#602.2) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [602.4 Alternate Formats for Non-Electronic Support Documentation](https://www.access-board.gov/ict/#602.4) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [603.2 Information on Accessibility and Compatibility Features](https://www.access-board.gov/ict/#603.2) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+| [603.3 Accommodation of Communication Needs](https://www.access-board.gov/ict/#603.3) | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
+
+
+## Legal Disclaimer
+The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.

--- a/opat/drupal-9.yaml
+++ b/opat/drupal-9.yaml
@@ -1,0 +1,838 @@
+title: Drupal Accessibility Conformance Report
+product:
+  name: Drupal
+  version: "9.1"
+  description: Content Management System
+author:
+  name: Mike Gifford
+  company_name: CivicActions
+  address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549
+  email: mike.gifford@civicactions.com
+  phone: (510) 408-7510
+  website: https://civicactions.com/
+notes: Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+evaluation_methods_used: Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+legal_disclaimer: The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
+chapters:
+  success_criteria_level_a:
+    notes: "Drupal doesn't make a strong distinction between the front-end & back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation."
+    criteria:
+      - num: "1.1.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Drupal 8 requires alt text for images by default.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Some non-textual content in the documentation does not provide a textual alternative.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The back end of Drupal Core was built to be  WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue 3002770.
+      - num: "1.2.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: This is not explicitly defined in the documentation.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: There is no additional support for authors within the authoring interface to explain how this can be done.
+      - num: "1.2.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "does-not-support"
+              notes: The file module in Core lets authors upload audio and video content, and output <audio> and <video> elements and does not support captions.
+          - name: "electronic-docs"
+            adherence:
+              level: not-applicable
+          - name: "software"
+            adherence:
+              level: not-applicable
+          - name: "authoring-tool"
+            adherence:
+              level: "does-not-support"
+              notes: Drupal does not support, let alone require users to include captions. Hard coding open captions is presently the only way to satisfy this in Core.
+      - num: "1.2.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "does-not-support"
+              notes: Audio files can be uploaded, but there is no way to associate captions in Core.
+          - name: "electronic-docs"
+            adherence:
+              level: "does-not-support"
+              notes: There is no documentation on how to properly convey pre-recorded audio descriptions.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "does-not-support"
+              notes: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.
+      - num: "1.3.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Information is structured into logical relationships. Navigational lists are well used to group information. Forms have a visual and semantic representation for required fields. Message windows have ARIA role defined incorrectly as role=contentinfo which impacts content relationships - Drupal issue 2942404. aria-live announcement is not contained in a landmark - Drupal issue 3098857.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Information is structured into logical relationships. Navigational lists are well used to group information.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).
+      - num: "1.3.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Drupal Core has been extensively tested with keyboard only users. As a proudly multilingual CMS, Drupal provides support for bidirectional navigation.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).
+      - num: "1.3.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Where possible Drupal Core uses combinations of text and symbols for the user interface.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The authoring interface has been developed to not rely on symbols alone to convey information to the user.
+      - num: "1.4.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Color is not used without text and often symbols to convey meaning.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: In general, the admin theme is very accessible. The Claro Administration Theme shortcut start needs improvement - Drupal issue 3171726.
+      - num: "1.4.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "not-applicable"
+      - num: "2.1.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Users can interact with Drupal Core with the keyboard and without specific timings for individual keystrokes.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: Authors are largely able to engage with Drupal Core with the keyboard and without specific timings for individual keystrokes. Tooltips not displayed for keyboard navigation - Drupal issue 2933984. There are reported issues with IE11 and JAWS - Drupal issue 2852702. It is worth noting that Drupal's admin is powerful and complex, and there are other accessibility reports in the issue queue.
+      - num: "2.1.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Focus can be moved away from that component using only a keyboard interface.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Focus can be moved away from that component using only a keyboard interface.
+      - num: "2.2.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: The time limit is longer than 20 hours.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The time limit is longer than 20 hours.
+      - num: "2.2.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "not-applicable"
+      - num: "2.3.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: There are no flashing elements in Drupal Core.
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: There are no flashing elements in Drupal Core.
+      - num: "2.4.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Skip links are provided.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Skip links are provided.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Skip links are provided.
+      - num: "2.4.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.
+      - num: "2.4.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Focusable components receive focus in an order that preserves meaning and operability.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Focusable components receive focus in an order that preserves meaning and operability.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Focusable components receive focus in an order that preserves meaning and operability.
+      - num: "2.4.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Careful attention has been paid to ensure that automated "Read More" links are available in a way that is available with contextual information for screen readers.
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Careful attention has been paid to ensure that automated "Read More" links are available in a way that is available with contextual information for screen readers.
+      - num: "3.1.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Page language is defined semantically on every page.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Page language is defined semantically on every page.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Page language is defined semantically on every page.
+      - num: "3.2.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Change in the focus state does not initiate a change of context for the user.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Change in the focus state does not initiate a change of context for the user.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Change in the focus state does not initiate a change of context for the user.
+      - num: "3.2.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Engaging with the interactive sites does not unexpectedly take control from the users.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Engaging with the interactive sites does not unexpectedly take control from the users.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Engaging with the interactive sites does not unexpectedly take control from the users.
+      - num: "3.3.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.
+      - num: "3.3.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Default forms all include labels.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: There are a few places where there are problems with labels, but these are odd exceptions - Drupal issue 3015494.
+      - num: "4.1.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: There are no HTML5 errors or warnings that are known to impact assistive technology users.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: There are no HTML5 errors or warnings that are known to impact assistive technology users.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Generally parsing is very well supported, but there are a few places where this needs to be improved - Drupal issue 1852090 and 3144948.
+      - num: "4.1.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Public pages support this criterion.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Public pages support this criterion.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: This is generally well supported, but there are places where it has been overlooked. Drupal issue 3144948, 3019487, and 3085545.
+  success_criteria_level_aa:
+    criteria:
+      - num: "1.2.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+      - num: "1.2.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "does-not-support"
+              notes: Audio files can be uploaded, but there is no way to associate captions in Core.
+          - name: "electronic-docs"
+            adherence:
+              level: "does-not-support"
+              notes: There is no documentation on how to properly convey pre-recorded audio descriptions.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "does-not-support"
+              notes: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.
+      - num: "1.4.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Generally meets. Some contrast failures around grey backgrounds - Drupal issue 3040673.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: The docs have sufficient contrast.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Generally meets requirements. Some challenges with Core admin themes - Drupal issue 930508 and 3080100.
+      - num: "1.4.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Generally support with some minor exceptions - Drupal issue 3129257.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: The docs are accessible up to 200%.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: Generally good with some exceptions - Drupal issue 3164587.
+      - num: "1.4.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Text is generally styled with CSS in the authoring tool. Should images of text be uploaded by the user, they will be required to add alternative text.
+      - num: "2.4.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: There is more than one way to locate a Web page within the CMS.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: There is more than one way to locate a Web page within the CMS.
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: There is more than one way to locate a Web page within the CMS.
+      - num: "2.4.6"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Generally there is very good support. Some heading levels may be missed in some unique contexts - Drupal issue 1768732. Better support could be provided for threaded comments - Drupal issue 2290043.
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: Generally good, but for dynamic elements like the Layout Builder need a plan for a dynamic heading structure - Drupal issue 3007978.
+      - num: "2.4.7"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Focus elements are well established for the front-end. Further enhancements are being developed to make it more obvious for keyboard only users.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: An IE specific bug where there are focus issues for authors and administrators in the Claro theme - Drupal issue 3048785.
+      - num: "3.1.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: Multilingual sites have language switchers with proper semantics. Unfotunately support is lacking for multi-lingual search 2992894 as well as both the Filesystem 3163915 & Views components 2496223.
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Drupal has good support for multilingual content and accessibility. To support the Language of Parts for authors, a button can be added to simplify the process of adding language specific phrases.
+      - num: "3.2.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Drupal's menu structure allows for consistent navigation across the site.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Drupal's menu structure allows for consistent navigation across the site.
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Drupal's menu structure allows for consistent navigation across the site.
+      - num: "3.2.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Components in Drupal that have the same functionality are identified consistently.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Components in Drupal that have the same functionality are identified consistently.
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Components in Drupal that have the same functionality are identified consistently.
+      - num: "3.3.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.
+          - name: "electronic-docs"
+            adherence:
+              level: "not-applicable"
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.
+      - num: "3.3.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: By default users can editing content which they own.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Documentation could be improved.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+          - name: "authoring-tool"
+            adherence:
+              level: "partially-supports"
+              notes: There is nothing to differentiate editing financial or legal data from any other data managed by Drupal.
+  success_criteria_level_aaa:
+    notes: Where possible the Drupal community strives to exceed AA compliance.
+    criteria:
+      - num: "1.2.6"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "1.2.7"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "1.2.8"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "1.2.9"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "1.4.6"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: A front-end and back-end theme could be configured to allow this to comply.
+      - num: "1.4.7"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "1.4.8"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-evaluated"
+              notes: Stable Core themes leave much of the presentation of text to user agents, so aside from line spacing this generally works.
+      - num: "1.4.9"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Text images are all supplied by the author.
+      - num: "2.1.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: The web front-end is not a barrier to keyboard only users.
+      - num: "2.2.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: There are no timeouts in Drupal Core that would affect people with disabilities.
+      - num: "2.2.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "2.2.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "2.3.2"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: There is no flashing content.
+      - num: "2.4.8"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Breadcrumbs are available and sitemap modules can be added to provide additional means for navigation.
+      - num: "2.4.9"
+        components:
+          - name: "web"
+            adherence:
+              level: "partially-supports"
+              notes: There is a mechanism to support automated links with semantic descriptive titles.
+      - num: "2.4.10"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Drupal provides heading elements at the beginning of each section of content.
+      - num: "3.1.3"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.1.4"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.1.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.1.6"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.2.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.3.5"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+      - num: "3.3.6"
+        components:
+          - name: "web"
+            adherence:
+              level: "not-applicable"
+  functional_performance_criteria:
+    notes: Not applicable.
+    criteria:
+      - num: "302.1"
+        components:
+          - name: "none"
+            adherence:
+              level: "supports"
+              notes: Testing has been done with JAWS, NVDA and VoiceOver.
+      - num: "302.2"
+        components:
+          - name: "none"
+            adherence:
+              level: "supports"
+              notes: Testing has been done with browser zoom and ZoomText.
+      - num: "302.3"
+        components:
+          - name: "none"
+            adherence:
+              level: "supports"
+              notes: The interface has been reviewed for use of color.
+      - num: "302.4"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "302.5"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "302.6"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "302.7"
+        components:
+          - name: "none"
+            adherence:
+              level: "supports"
+              notes: Drupal's interface does not restrict users with limited manipulation.
+      - num: "302.8"
+        components:
+          - name: "none"
+            adherence:
+              level: "supports"
+              notes: Drupal's interface does not restrict users with limited reach or strength.
+      - num: "302.9"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+  # Chapter 4
+  hardware:
+    notes: "Drupal is a web application. Hardware accessibility criteria is not applicable."
+  # Chapter 5
+  software:
+    notes: "Drupal is a web application. Software accessibility criteria is not applicable."
+  # Chapter 6
+  support_documentation_and_services:
+    notes: "Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available."
+    criteria:
+      - num: "602.2"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "602.4"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "603.2"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"
+      - num: "603.3"
+        components:
+          - name: "none"
+            adherence:
+              level: "not-applicable"

--- a/opat/index.html
+++ b/opat/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>OPAT Accessibility Conformance Reports</title>
+    <link rel="stylesheet" type="text/css" href="reports.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.css"
+    />
+    <script
+      src="https://code.jquery.com/jquery-3.6.0.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      type="text/javascript"
+      charset="utf8"
+      src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.js"
+    ></script>
+    <script type="text/javascript" charset="utf8" src="reports.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>OPAT Accessibility Conformance Reports</h1>
+    </header>
+    <main>
+      <table id="reports" class="display">
+        <caption>
+          List of available ACRs and their OPAT versions.
+        </caption>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Product/Version</th>
+            <th>Description</th>
+            <th>Markdown</th>
+            <th>OPAT</th>
+            <th>Version</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </main>
+    <footer>
+      <p>
+        <a href="https://github.com/GSA/open-product-accessibility-template"
+          >OPAT</a
+        >
+        is a format maintained by the <a href="https://gsa.gov/">GSA</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/opat/opat-list.json
+++ b/opat/opat-list.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    [
+      "<a href='drupal-9.html'>Drupal Accessibility Conformance Report</a>",
+      "Drupal 9.1",
+      "Content Management System",
+      "<a href='drupal-9.markdown'>Markdown</a>",
+      "<a href='drupal-9.yaml'>OPAT</a>",
+      "<a href='../catalog/2.4-edition-wcag-2.0-508-en.yaml'>VPAT® 2.4 Revised Section 508 Edition</a>"
+    ]
+  ]
+}

--- a/opat/opat.css
+++ b/opat/opat.css
@@ -1,0 +1,89 @@
+/* Default OPAT styling */
+
+body {
+  padding: 2em 1em 2em 70px;
+  margin: 0;
+  font-family: sans-serif;
+  color: black;
+  background: white no-repeat fixed top left;
+}
+:link {
+  color: #00c;
+  background: transparent;
+}
+:visited {
+  color: #609;
+  background: transparent;
+}
+a:active {
+  color: #c00;
+  background: transparent;
+}
+
+.header-anchor {
+  margin-left: -1em;
+  visibility: hidden;
+}
+
+:hover > .header-anchor {
+  visibility: visible;
+}
+
+th,
+td {
+  font-family: sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-align: left;
+}
+h1,
+h2,
+h3 {
+  color: black;
+  background: white;
+}
+h1 {
+  font: 170% sans-serif;
+}
+h2 {
+  font: 140% sans-serif;
+}
+h3 {
+  font: 120% sans-serif;
+}
+h4 {
+  font: bold 100% sans-serif;
+}
+h5 {
+  font: italic 100% sans-serif;
+}
+h6 {
+  font: small-caps 100% sans-serif;
+}
+
+table th {
+  text-align: left;
+  background-color: #ccc;
+}
+
+table th,
+table td {
+  padding: 0.5em;
+  border: 1px solid #999;
+}
+
+footer {
+  font-size: 80%;
+  font-weight: 800;
+  top: 5px;
+  left: 100%;
+  margin-top: 50px;
+  border-top: 5px solid #171d22;
+  width: 90%;
+}

--- a/opat/reports.css
+++ b/opat/reports.css
@@ -1,0 +1,86 @@
+/* Default OPAT styling */
+
+body {
+  font-family: sans-serif;
+  color: black;
+  background: white no-repeat fixed top left;
+}
+:link {
+  color: #00c;
+  background: transparent;
+}
+:visited {
+  color: #609;
+  background: transparent;
+}
+a:active {
+  color: #c00;
+  background: transparent;
+}
+
+.header-anchor {
+  margin-left: -1em;
+  visibility: hidden;
+}
+
+:hover > .header-anchor {
+  visibility: visible;
+}
+
+th,
+td {
+  font-family: sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-align: left;
+}
+h1,
+h2,
+h3 {
+  color: black;
+  background: white;
+}
+h1 {
+  font: 170% sans-serif;
+}
+h2 {
+  font: 140% sans-serif;
+}
+h3 {
+  font: 120% sans-serif;
+}
+h4 {
+  font: bold 100% sans-serif;
+}
+h5 {
+  font: italic 100% sans-serif;
+}
+h6 {
+  font: small-caps 100% sans-serif;
+}
+
+table th {
+  text-align: left;
+  background-color: #ccc;
+}
+
+table th,
+table td {
+  padding: 0.5em;
+  border: 1px solid #999;
+}
+
+footer {
+  font-size: 80%;
+  font-weight: 800;
+  top: 5px;
+  left: 100%;
+  margin-top: 50px;
+  border-top: 5px solid #171d22;
+}

--- a/opat/reports.js
+++ b/opat/reports.js
@@ -1,0 +1,5 @@
+$(document).ready(function () {
+  $("#reports").DataTable({
+    ajax: "opat-list.json",
+  });
+});


### PR DESCRIPTION
This will add the searchable index of the OPATs to the Jekyll website.

Preview link: https://federalist-02947dd8-86df-467a-b2af-4c5b94c5b1f0.app.cloud.gov/preview/gsa/opat-website/opats/opat/

Looks like the iframed version https://federalist-02947dd8-86df-467a-b2af-4c5b94c5b1f0.app.cloud.gov/preview/gsa/opat-website/opats/opats/ is not working but maybe that can be resolved when we go live or merge this.

Tagged everyone just to take a look. I will also submit a pull request in the main repo that will contain the main version and documentation of this.